### PR TITLE
Upgrade dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 dist
-package-lock.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "commander": "^2.20.3",
     "got": "^11.8.2",
-    "opn": "^5.5.0"
+    "open": "^8.0.7"
   },
   "devDependencies": {
     "@babel/cli": "^7.13.16",

--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
   },
   "homepage": "https://github.com/pastak/chrome-webstore-manager",
   "dependencies": {
-    "commander": "^2.8.1",
-    "opn": "^5.4.0",
+    "commander": "^2.20.3",
+    "opn": "^5.5.0",
     "request-promise": "^0.4.3"
   },
   "devDependencies": {
-    "@babel/cli": "^7.0.0",
-    "@babel/core": "^7.0.0",
-    "@babel/preset-env": "^7.0.0",
+    "@babel/cli": "^7.13.16",
+    "@babel/core": "^7.14.0",
+    "@babel/preset-env": "^7.14.1",
     "standard": "^12.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "homepage": "https://github.com/pastak/chrome-webstore-manager",
   "dependencies": {
     "commander": "^2.20.3",
-    "opn": "^5.5.0",
-    "request-promise": "^0.4.3"
+    "got": "^11.8.2",
+    "opn": "^5.5.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.13.16",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Command Line Tool for Publish Chrome WebStore",
   "main": "./dist/libs/chrome-webstore.js",
   "scripts": {
-    "test": "standard ./**/*js",
+    "test": "standard ./src/**/*js",
     "build": "babel src -d dist",
     "prepublish": "npm run build"
   },
@@ -30,6 +30,6 @@
     "@babel/cli": "^7.13.16",
     "@babel/core": "^7.14.0",
     "@babel/preset-env": "^7.14.1",
-    "standard": "^12.0.1"
+    "standard": "^16.0.3"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -10,8 +10,7 @@ var ChromeWebstore = require('./libs/chrome-webstore.js')
 var getAccessToken = function (cid, cs, code) {
   const chromeWebstore = new ChromeWebstore(cid, cs)
   chromeWebstore.getAccessToken(code)
-    .then(function (data) {
-      var json = JSON.parse(data)
+    .then(function (json) {
       console.log('Your token: ' + json.access_token)
       console.log('Your refresh_token: ' + json.refresh_token)
       process.exit()
@@ -56,8 +55,7 @@ program
     var token = getToken(options)
     var fileBin = fs.readFileSync(zipFile)
     const chromeWebstore = new ChromeWebstore()
-    chromeWebstore.insertItem(token, fileBin).then(function (data) {
-      var json = JSON.parse(data)
+    chromeWebstore.insertItem(token, fileBin).then(function (json) {
       if (json.itemError) {
         console.error(json.itemError)
         return process.exit(1)
@@ -74,8 +72,7 @@ program
     var fileBin = fs.readFileSync(zipFile)
     var token = getToken(options)
     const chromeWebstore = new ChromeWebstore()
-    chromeWebstore.updateItem(token, fileBin, itemId).then(function (data) {
-      var json = JSON.parse(data)
+    chromeWebstore.updateItem(token, fileBin, itemId).then(function (json) {
       if (json.itemError) {
         console.error(json.itemError)
         return process.exit(1)
@@ -93,8 +90,7 @@ program
     const token = getToken(options)
     var projection = options.projection || 'DRAFT'
     const chromeWebstore = new ChromeWebstore()
-    chromeWebstore.getItem(token, itemId, projection).then(function (data) {
-      var json = JSON.parse(data)
+    chromeWebstore.getItem(token, itemId, projection).then(function (json) {
       if (json.itemError) {
         console.error(json.itemError)
         return process.exit(1)
@@ -112,8 +108,7 @@ program
     var token = getToken(options)
     var target = options.target || 'default'
     const chromeWebstore = new ChromeWebstore()
-    chromeWebstore.publishItem(token, itemId, target).then(function (data) {
-      var json = JSON.parse(data)
+    chromeWebstore.publishItem(token, itemId, target).then(function (json) {
       if (json.itemError) {
         console.error(json.itemError)
         return process.exit(1)
@@ -140,8 +135,7 @@ program
     }
     var refreshToken = options.refresh_token || process.env.WEBSTORE_REFRESH_TOKEN
     const chromeWebstore = new ChromeWebstore(cid, cs)
-    chromeWebstore.getRefreshToken(refreshToken).then(function (data) {
-      var json = JSON.parse(data)
+    chromeWebstore.getRefreshToken(refreshToken).then(function (json) {
       console.log(json.access_token)
     })
   })

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@
 var readline = require('readline')
 var fs = require('fs')
 var program = require('commander')
-var open = require('opn')
+var open = require('open')
 var getToken = require('./libs/getToken')
 var ChromeWebstore = require('./libs/chrome-webstore.js')
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 
-var readline = require('readline')
-var fs = require('fs')
-var program = require('commander')
-var open = require('open')
-var getToken = require('./libs/getToken')
-var ChromeWebstore = require('./libs/chrome-webstore.js')
+const readline = require('readline')
+const fs = require('fs')
+const program = require('commander')
+const open = require('open')
+const getToken = require('./libs/getToken')
+const ChromeWebstore = require('./libs/chrome-webstore.js')
 
-var getAccessToken = function (cid, cs, code) {
+const getAccessToken = function (cid, cs, code) {
   const chromeWebstore = new ChromeWebstore(cid, cs)
   chromeWebstore.getAccessToken(code)
     .then(function (json) {
@@ -27,7 +27,7 @@ program
   .option('--client_secret [Client_Secret]', 'Your Client Secret')
   .option('--code [CODE]', 'Your authorized code')
   .action(function (options) {
-    var rli = readline.createInterface(process.stdin, process.stdout)
+    const rli = readline.createInterface(process.stdin, process.stdout)
     const cid = options.client_id
     const cs = options.client_secret
     if (!(cid && cs)) {
@@ -52,8 +52,8 @@ program
   .description('create new item on Chrome Web Store')
   .option('-t, --token [YOUR_TOKEN]', 'Your token')
   .action(function (zipFile, options) {
-    var token = getToken(options)
-    var fileBin = fs.readFileSync(zipFile)
+    const token = getToken(options)
+    const fileBin = fs.readFileSync(zipFile)
     const chromeWebstore = new ChromeWebstore()
     chromeWebstore.insertItem(token, fileBin).then(function (json) {
       if (json.itemError) {
@@ -69,8 +69,8 @@ program
   .description('update your item')
   .option('-t, --token [YOUR_TOKEN]', 'Your token')
   .action(function (itemId, zipFile, options) {
-    var fileBin = fs.readFileSync(zipFile)
-    var token = getToken(options)
+    const fileBin = fs.readFileSync(zipFile)
+    const token = getToken(options)
     const chromeWebstore = new ChromeWebstore()
     chromeWebstore.updateItem(token, fileBin, itemId).then(function (json) {
       if (json.itemError) {
@@ -88,7 +88,7 @@ program
   .option('--projection [PROJECTION_TYPE]', '"DRAFT" or "PUBLISHED"')
   .action(function (itemId, options) {
     const token = getToken(options)
-    var projection = options.projection || 'DRAFT'
+    const projection = options.projection || 'DRAFT'
     const chromeWebstore = new ChromeWebstore()
     chromeWebstore.getItem(token, itemId, projection).then(function (json) {
       if (json.itemError) {
@@ -105,8 +105,8 @@ program
   .option('-t, --token [YOUR_TOKEN]', 'Your token')
   .option('--target [TARGET_TYPE]', '"trustedTesters" or "default"')
   .action(function (itemId, options) {
-    var token = getToken(options)
-    var target = options.target || 'default'
+    const token = getToken(options)
+    const target = options.target || 'default'
     const chromeWebstore = new ChromeWebstore()
     chromeWebstore.publishItem(token, itemId, target).then(function (json) {
       if (json.itemError) {
@@ -133,7 +133,7 @@ program
       console.error('Require refresh_token')
       process.exit(1)
     }
-    var refreshToken = options.refresh_token || process.env.WEBSTORE_REFRESH_TOKEN
+    const refreshToken = options.refresh_token || process.env.WEBSTORE_REFRESH_TOKEN
     const chromeWebstore = new ChromeWebstore(cid, cs)
     chromeWebstore.getRefreshToken(refreshToken).then(function (json) {
       console.log(json.access_token)

--- a/src/libs/chrome-webstore.js
+++ b/src/libs/chrome-webstore.js
@@ -1,4 +1,4 @@
-const request = require('request-promise')
+const got = require('got')
 module.exports = class ChromeWebStore {
   constructor (cid, cs, redirectUrl) {
     this.cid = cid
@@ -11,61 +11,65 @@ module.exports = class ChromeWebStore {
     return 'https://accounts.google.com/o/oauth2/auth?response_type=code&scope=https://www.googleapis.com/auth/chromewebstore&client_id=' + this.cid + '&state' + state + '&redirect_uri=' + (redirectUrl || this.redirectUrl)
   }
   getAccessToken (code, redirectUrl) {
-    return request.post('https://accounts.google.com/o/oauth2/token')
-      .form({
-        client_id: this.cid,
-        client_secret: this.cs,
-        code: code,
-        grant_type: 'authorization_code',
-        redirect_uri: redirectUrl || this.redirectUrl
-      })
+    return got.post('https://accounts.google.com/o/oauth2/token',
+      {
+        form: {
+          client_id: this.cid,
+          client_secret: this.cs,
+          code: code,
+          grant_type: 'authorization_code',
+          redirect_uri: redirectUrl || this.redirectUrl
+        }
+      }).json()
   }
   insertItem (token, fileBin) {
-    return request.post({
-      uri: 'https://www.googleapis.com/upload/chromewebstore/v1.1/items',
-      headers: {
-        Authorization: 'Bearer ' + token,
-        'x-goog-api-version': 2
-      },
-      body: fileBin
-    })
+    return got.post('https://www.googleapis.com/upload/chromewebstore/v1.1/items',
+      {
+        headers: {
+          Authorization: 'Bearer ' + token,
+          'x-goog-api-version': 2
+        },
+        body: fileBin
+      }).json()
   }
   getItem (token, itemId, projection = 'DRAFT') {
-    return request.get({
-      uri: 'https://www.googleapis.com//chromewebstore/v1.1/items/' + itemId + '?projection=' + projection,
-      headers: {
-        Authorization: 'Bearer ' + token,
-        'x-goog-api-version': 2
-      }
-    })
+    return got.get('https://www.googleapis.com//chromewebstore/v1.1/items/' + itemId + '?projection=' + projection,
+      {
+        headers: {
+          Authorization: 'Bearer ' + token,
+          'x-goog-api-version': 2
+        }
+      }).json()
   }
   updateItem (token, fileBin, itemId) {
-    return request({
-      method: 'PUT',
-      uri: 'https://www.googleapis.com/upload/chromewebstore/v1.1/items/' + itemId,
-      headers: {
-        Authorization: 'Bearer ' + token,
-        'x-goog-api-version': 2
-      },
-      body: fileBin,
-      timeout: 120 * 1000
-    })
+    return got.put('https://www.googleapis.com/upload/chromewebstore/v1.1/items/' + itemId,
+      {
+        headers: {
+          Authorization: 'Bearer ' + token,
+          'x-goog-api-version': 2
+        },
+        body: fileBin,
+        timeout: 120 * 1000
+      }).json()
   }
   publishItem (token, itemId, target = 'default') {
-    return request.post({
-      uri: 'https://www.googleapis.com//chromewebstore/v1.1/items/' + itemId + '/publish?publishTarget=' + target,
-      headers: {
-        Authorization: 'Bearer ' + token,
-        'x-goog-api-version': 2
-      }
-    })
+    return got.post('https://www.googleapis.com//chromewebstore/v1.1/items/' + itemId + '/publish?publishTarget=' + target,
+      {
+        headers: {
+          Authorization: 'Bearer ' + token,
+          'x-goog-api-version': 2
+        }
+      })
   }
   getRefreshToken (refreshToken) {
-    return request.post('https://www.googleapis.com/oauth2/v3/token', { form: {
-      client_id: this.cid,
-      client_secret: this.cs,
-      grant_type: 'refresh_token',
-      refresh_token: refreshToken
-    } })
+    return got.post('https://www.googleapis.com/oauth2/v3/token',
+      {
+        form: {
+          client_id: this.cid,
+          client_secret: this.cs,
+          grant_type: 'refresh_token',
+          refresh_token: refreshToken
+        }
+      }).json()
   }
 }

--- a/src/libs/chrome-webstore.js
+++ b/src/libs/chrome-webstore.js
@@ -5,11 +5,13 @@ module.exports = class ChromeWebStore {
     this.cs = cs
     this.redirectUrl = redirectUrl || 'urn:ietf:wg:oauth:2.0:oob'
   }
+
   getCodeUrl (redirectUrl, state) {
     state = state || ''
     state = encodeURIComponent(state)
     return 'https://accounts.google.com/o/oauth2/auth?response_type=code&scope=https://www.googleapis.com/auth/chromewebstore&client_id=' + this.cid + '&state' + state + '&redirect_uri=' + (redirectUrl || this.redirectUrl)
   }
+
   getAccessToken (code, redirectUrl) {
     return got.post('https://accounts.google.com/o/oauth2/token',
       {
@@ -22,6 +24,7 @@ module.exports = class ChromeWebStore {
         }
       }).json()
   }
+
   insertItem (token, fileBin) {
     return got.post('https://www.googleapis.com/upload/chromewebstore/v1.1/items',
       {
@@ -32,6 +35,7 @@ module.exports = class ChromeWebStore {
         body: fileBin
       }).json()
   }
+
   getItem (token, itemId, projection = 'DRAFT') {
     return got.get('https://www.googleapis.com//chromewebstore/v1.1/items/' + itemId + '?projection=' + projection,
       {
@@ -41,6 +45,7 @@ module.exports = class ChromeWebStore {
         }
       }).json()
   }
+
   updateItem (token, fileBin, itemId) {
     return got.put('https://www.googleapis.com/upload/chromewebstore/v1.1/items/' + itemId,
       {
@@ -52,6 +57,7 @@ module.exports = class ChromeWebStore {
         timeout: 120 * 1000
       }).json()
   }
+
   publishItem (token, itemId, target = 'default') {
     return got.post('https://www.googleapis.com//chromewebstore/v1.1/items/' + itemId + '/publish?publishTarget=' + target,
       {
@@ -61,6 +67,7 @@ module.exports = class ChromeWebStore {
         }
       })
   }
+
   getRefreshToken (refreshToken) {
     return got.post('https://www.googleapis.com/oauth2/v3/token',
       {


### PR DESCRIPTION
- Upgrade most NPM packages to their most recent version.
- In particular, replace the deprecated `request-promise` with `got`.
- Resolves security audit warnings for those who depend on `chrome-webstore-manager`.

See

- https://github.com/request/request-promise#deprecated